### PR TITLE
sqlalchemy.ext.declarative is deprecated

### DIFF
--- a/docs/examples/models_orm_mode.py
+++ b/docs/examples/models_orm_mode.py
@@ -1,7 +1,7 @@
 from typing import List
 from sqlalchemy import Column, Integer, String
 from sqlalchemy.dialects.postgresql import ARRAY
-from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import declarative_base
 from pydantic import BaseModel, constr
 
 Base = declarative_base()


### PR DESCRIPTION
Hey guys!

According to the [SqlAlchemy documentation](https://docs.sqlalchemy.org/en/14/orm/declarative_tables.html) `sqlalchemy.ext.declarative` is deprecated.

The fix for `sqlalchemy.orm` avoids the warning message below:

```
Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message.
```

In my case. I'm using __Python 3.11.1__ and and the following `requirements.txt`:

```
attrs==22.2.0
greenlet==2.0.1
iniconfig==2.0.0
packaging==23.0
pluggy==1.0.0
pydantic==1.10.4
pytest==7.2.1
SQLAlchemy==1.4.46
typing_extensions==4.4.0
```

Hope I helped!